### PR TITLE
Enable the master data for Chief Complaint QC

### DIFF
--- a/src/main/java/com/iemr/tm/service/common/master/CommonMasterServiceImpl.java
+++ b/src/main/java/com/iemr/tm/service/common/master/CommonMasterServiceImpl.java
@@ -120,7 +120,9 @@ public class CommonMasterServiceImpl implements CommonMaterService {
 				break;
 			case 7: {
 				// 7 : General OPD (QC)
-				nurseMasterData = "No Master Data found for QuickConsultation";
+				// nurseMasterData = "No Master Data found for QuickConsultation";
+				nurseMasterData = ancMasterDataServiceImpl
+						.getCommonNurseMasterDataForGenopdAncNcdcarePnc(visitCategoryID, providerServiceMapID, gender);
 			}
 				break;
 			case (8): {


### PR DESCRIPTION
## 📋 Description

JIRA ID: 

Currently, the master data didn't get loaded on selecting the Chief Complaint QC option from HWC module.  This change enables the master data in the chief complaint.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of nurse master data retrieval for General OPD (QC) visits, ensuring relevant data is now displayed instead of a placeholder message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->