### PR TITLE
fix: not allow invalid user from mobile application

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.iemr.tm</groupId>
 	<artifactId>tm-api</artifactId>
-	<version>3.1.0</version>
+	<version>3.2.1</version>
 	<packaging>war</packaging>
 
 	<name>TM-API</name>


### PR DESCRIPTION
## 📋 Description

JIRA ID: [AMM-1867](https://support.piramalfoundation.org/jira/browse/AMM-1867)

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

The preHandle method in tm-api intercepts the request and extracts the Authorization header. If the header is missing or empty, the request proceeds without validation. For other requests, it tries to validate the session key using the validator.checkKeyExists() method.

Currently, the checkKeyExists method is missing in tm-api, so the request falls back to common-api (connected to another service), which throws a generic 5000 error without proper validation.

The correct checkKeyExists method should be implemented in tm-api to validate the login key and optionally the IP address


Currently, preHandle does not correctly handle this, which results in returning 5002 status (USERID_FAILURE) from the generic error handler. The OutputResponse class maps exceptions to status codes:

SUCCESS = 200

GENERIC_FAILURE = 5000

OBJECT_FAILURE = 5001

USERID_FAILURE = 5002

PASSWORD_FAILURE = 5003

...

For IEMRException, the response sets:

statusCode = USERID_FAILURE (5002)

status = "User login failed"

errorMessage = <exception message>

Summary: The 5000 error occurs because the session key validation is missing in tm-api. Implementing checkKeyExists in tm-api ensures validation happens at an earlier stage, preventing fallback to common-api and returning proper error codes (like 5002) with meaningful messages.

Attch the RCA doc https://pmp.piramalswasthya.org/confluence/spaces/AMRIT/pages/111017986/AMM-1867+Registration+Page+API+Error
