### PR TITLE
Secure file download via API proxy instead of credential-exposed URL

### DIFF
--- a/src/main/java/com/iemr/tm/repo/nurse/BenVisitDetailRepo.java
+++ b/src/main/java/com/iemr/tm/repo/nurse/BenVisitDetailRepo.java
@@ -91,6 +91,9 @@ public interface BenVisitDetailRepo extends CrudRepository<BeneficiaryVisitDetai
 	@Query(nativeQuery = true, value = " SELECT FileUID from t_kmfilemanager where KmFileManagerID = :fileID ")
 	public String getFileUUID(@Param("fileID") int fileID);
 
+	@Query(nativeQuery = true, value = " SELECT FileName from t_kmfilemanager where KmFileManagerID = :fileID ")
+	public String getFileName(@Param("fileID") int fileID);
+
 	// get file uuid from file id
 	@Transactional
 	@Modifying

--- a/src/main/java/com/iemr/tm/service/common/transaction/CommonServiceImpl.java
+++ b/src/main/java/com/iemr/tm/service/common/transaction/CommonServiceImpl.java
@@ -565,7 +565,9 @@ public class CommonServiceImpl implements CommonService {
 		String fileUUID = null;
 		JSONObject obj = new JSONObject(requestOBJ);
 		if (obj.has("fileID")) {
-			fileUUID = benVisitDetailRepo.getFileUUID(obj.getInt("fileID"));
+			int fileID = obj.getInt("fileID");
+			fileUUID = benVisitDetailRepo.getFileUUID(fileID);
+			String fileName = benVisitDetailRepo.getFileName(fileID);
 
 			logger.info("fileUUID for fileID " + obj.getInt("fileID") + " is " + fileUUID);
 			logger.info("openkmDocUrl is " + openkmDocUrl);
@@ -599,7 +601,10 @@ public class CommonServiceImpl implements CommonService {
 								}
 								try (InputStream is = conn.getInputStream()) {
 									byte[] fileBytes = is.readAllBytes();
-									return Base64.getEncoder().encodeToString(fileBytes);
+									JSONObject result = new JSONObject();
+									result.put("fileContent", Base64.getEncoder().encodeToString(fileBytes));
+									result.put("fileName", fileName != null ? fileName : "download");
+									return result.toString();
 								} finally {
 									conn.disconnect();
 								}

--- a/src/main/java/com/iemr/tm/service/common/transaction/CommonServiceImpl.java
+++ b/src/main/java/com/iemr/tm/service/common/transaction/CommonServiceImpl.java
@@ -21,8 +21,12 @@
 */
 package com.iemr.tm.service.common.transaction;
 
+import java.net.URL;
+import java.net.HttpURLConnection;
+import java.io.InputStream;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -554,7 +558,7 @@ public class CommonServiceImpl implements CommonService {
 
 	// end
 
-	public String getOpenKMDocURL(String requestOBJ, String Authorization) throws JSONException {
+	public String getOpenKMDocURL(String requestOBJ, String Authorization) throws Exception {
 		RestTemplate restTemplate = new RestTemplate();
 		HttpServletRequest requestHeader = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes())
 				.getRequest();
@@ -586,7 +590,19 @@ public class CommonServiceImpl implements CommonService {
 								String fileUrl = dataObj.getString("response");
 								// Fix malformed URL: https://user:pass@https://host -> https://user:pass@host
 								fileUrl = fileUrl.replaceAll("@https?://", "@");
-								return fileUrl;
+								// Download file from OpenKM and return as base64
+								URL url = new URL(fileUrl);
+								HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+								if (url.getUserInfo() != null) {
+									String basicAuth = "Basic " + Base64.getEncoder().encodeToString(url.getUserInfo().getBytes());
+									conn.setRequestProperty("Authorization", basicAuth);
+								}
+								try (InputStream is = conn.getInputStream()) {
+									byte[] fileBytes = is.readAllBytes();
+									return Base64.getEncoder().encodeToString(fileBytes);
+								} finally {
+									conn.disconnect();
+								}
 							}
 						}
 						return dataVal.toString();


### PR DESCRIPTION
## 📋 Description

JIRA ID: [AMM-2234](https://support.piramalfoundation.org/jira/browse/AMM-2234)
[AMM-2233](https://support.piramalfoundation.org/jira/browse/AMM-2233)

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---
- TM-API now downloads files from OpenKM server-side and returns base64 content with original fileName
- TM-UI decodes base64 and triggers browser download with correct file name
- OpenKM credentials no longer exposed to the browser
## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
