### PR TITLE
fix(stoptb): stamp VanSerialNo on i_ben_flow_outreach, require explic…

### DIFF
--- a/src/main/java/com/iemr/tm/service/benFlowStatus/CommonBenStatusFlowServiceImpl.java
+++ b/src/main/java/com/iemr/tm/service/benFlowStatus/CommonBenStatusFlowServiceImpl.java
@@ -67,9 +67,14 @@ public class CommonBenStatusFlowServiceImpl implements CommonBenStatusFlowServic
 
 			if (beneficiaryRegID != null && beneficiaryID != null && beneficiaryRegID > 0 && beneficiaryID > 0) {
 				objRS = beneficiaryFlowStatusRepo.save(obj);
-				if (objRS != null)
+				if (objRS != null) {
+					// VanSerialNo was never populated for i_ben_flow_outreach — following the
+					// same convention used elsewhere (VanSerialNo = record's own local PK, e.g.
+					// IdentityService.regMap.setVanSerialNo(regMap.getBenRegId())).
+					objRS.setVanSerialNo(objRS.getBenFlowID());
+					objRS = beneficiaryFlowStatusRepo.save(objRS);
 					returnOBJ = 1;
-				else
+				} else
 					returnOBJ = 0;
 			} else {
 				Calendar cal = Calendar.getInstance();
@@ -85,9 +90,11 @@ public class CommonBenStatusFlowServiceImpl implements CommonBenStatusFlowServic
 					returnOBJ = 3;
 				} else {
 					objRS = beneficiaryFlowStatusRepo.save(obj);
-					if (objRS != null)
+					if (objRS != null) {
+						objRS.setVanSerialNo(objRS.getBenFlowID());
+						objRS = beneficiaryFlowStatusRepo.save(objRS);
 						returnOBJ = 1;
-					else
+					} else
 						returnOBJ = 0;
 				}
 

--- a/src/main/java/com/iemr/tm/service/registrar/RegistrarServiceImpl.java
+++ b/src/main/java/com/iemr/tm/service/registrar/RegistrarServiceImpl.java
@@ -118,8 +118,10 @@ public class RegistrarServiceImpl implements RegistrarService {
 	private LettuceConnectionFactory redisConnectionFactory;
 
 	// When true, beneficiary registration fails loudly if camp is not configured
-	// instead of silently registering with vanID unset
-	@Value("${stoptb.enforce.vanid:false}")
+	// instead of silently registering with vanID unset. No inline default — every
+	// properties file must set this explicitly, so a forgotten config fails loudly
+	// at startup instead of running fail-open.
+	@Value("${stoptb.enforce.vanid}")
 	private boolean enforceVanID;
 
 	@Autowired


### PR DESCRIPTION
…it enforce.vanid config

- CommonBenStatusFlowServiceImpl.createBenFlowRecord: VanSerialNo was never set anywhere for i_ben_flow_outreach - now set to the row's own BenFlowID after save, matching the convention used elsewhere (e.g. IdentityService.regMap.setVanSerialNo(regMap.getBenRegId()))
- RegistrarServiceImpl: remove inline :false default from stoptb.enforce.vanid @Value - every properties file must set this explicitly now, so a forgotten config fails loudly at startup instead of running fail-open

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
