### PR TITLE
fix(stoptb): resolve district/village names from Nikshay tables, not …

### DIFF
--- a/src/main/java/com/iemr/tm/repo/benFlowStatus/BeneficiaryFlowStatusRepo.java
+++ b/src/main/java/com/iemr/tm/repo/benFlowStatus/BeneficiaryFlowStatusRepo.java
@@ -44,6 +44,32 @@ import com.iemr.tm.data.benFlowStatus.BeneficiaryFlowStatus;
 
 public interface BeneficiaryFlowStatusRepo extends CrudRepository<BeneficiaryFlowStatus, Long> {
 
+	// Targeted update — touches ONLY vanSerialNo. A full-entity save() here would also
+	// rewrite every other updatable column (e.g. `deleted`, which is insertable=false but
+	// NOT updatable=false) with whatever stale value the in-memory Java object happens to
+	// hold, silently clobbering the DB's own DEFAULT for columns never explicitly set.
+	@Transactional
+	@Modifying
+	@Query("UPDATE BeneficiaryFlowStatus t SET t.vanSerialNo = :vanSerialNo WHERE t.benFlowID = :id")
+	void updateVanSerialNo(@Param("id") Long id, @Param("vanSerialNo") Long vanSerialNo);
+
+	// Stop TB's district/village IDs are Nikshay-scoped, not AMRIT's general m_district/
+	// m_village numbering - the two ID spaces overlap (e.g. ID 1 means "Nicobars" in
+	// m_district but "Alluri Sitharama Raju" in m_nikshay_district), so client-sent text
+	// for these IDs can silently land on the wrong scheme's name. Gate any Nikshay-table
+	// resolution on this check first - a PSM with no Nikshay TU mapping is a non-Stop-TB
+	// program (ANC/NCD/cancer-screening/etc.) and must NOT go through the Nikshay tables.
+	@Query(value = "SELECT COUNT(*) FROM m_userservicerolemapping "
+			+ "WHERE ProviderServiceMapID = :psmId AND NikshayTUID IS NOT NULL AND Deleted = false LIMIT 1",
+			nativeQuery = true)
+	int countNikshayMappedUsersForPSM(@Param("psmId") Integer psmId);
+
+	@Query(value = "SELECT DistrictName FROM m_nikshay_district WHERE NikshayDistrictID = :id", nativeQuery = true)
+	String getNikshayDistrictName(@Param("id") Integer id);
+
+	@Query(value = "SELECT VillageName FROM m_nikshay_village WHERE NikshayVillageID = :id", nativeQuery = true)
+	String getNikshayVillageName(@Param("id") Integer id);
+
 	// nurse worklist
 //	@Query("SELECT  t from BeneficiaryFlowStatus t WHERE (t.nurseFlag = 1 OR t.nurseFlag = 100) AND (t.specialist_flag <> 100 OR t.specialist_flag is null) AND t.deleted = false "
 //			+ " AND Date(t.visitDate)  = curdate() AND t.providerServiceMapId = :providerServiceMapId "

--- a/src/main/java/com/iemr/tm/service/benFlowStatus/CommonBenStatusFlowServiceImpl.java
+++ b/src/main/java/com/iemr/tm/service/benFlowStatus/CommonBenStatusFlowServiceImpl.java
@@ -71,8 +71,11 @@ public class CommonBenStatusFlowServiceImpl implements CommonBenStatusFlowServic
 					// VanSerialNo was never populated for i_ben_flow_outreach — following the
 					// same convention used elsewhere (VanSerialNo = record's own local PK, e.g.
 					// IdentityService.regMap.setVanSerialNo(regMap.getBenRegId())).
-					objRS.setVanSerialNo(objRS.getBenFlowID());
-					objRS = beneficiaryFlowStatusRepo.save(objRS);
+					// A full-entity save() here (as this used to do) would also rewrite `deleted`
+					// (insertable=false but NOT updatable=false) with the in-memory object's never-set
+					// null, clobbering the DB's own DEFAULT b'0' and making the row invisible to every
+					// worklist query filtering `deleted = false` — use a targeted UPDATE instead.
+					beneficiaryFlowStatusRepo.updateVanSerialNo(objRS.getBenFlowID(), objRS.getBenFlowID());
 					returnOBJ = 1;
 				} else
 					returnOBJ = 0;
@@ -160,6 +163,34 @@ public class CommonBenStatusFlowServiceImpl implements CommonBenStatusFlowServic
 			obj.setVillageID(obj.getI_bendemographics().getDistrictBranchID());
 		if (obj.getI_bendemographics().getDistrictBranchName() != null)
 			obj.setVillageName(obj.getI_bendemographics().getDistrictBranchName());
+
+		// Stop TB's district/village IDs are Nikshay-scoped, not AMRIT's general m_district/
+		// m_village numbering - the same numeric ID can mean two different real places
+		// depending on the scheme, so the client-sent name text can silently be wrong.
+		// Only override for PSMs actually mapped to a Nikshay TU (i.e. genuinely Stop TB) -
+		// every other program (ANC/NCD/cancer-screening/etc.) keeps using client-sent text
+		// as before, since their IDs are correctly AMRIT-scoped already.
+		try {
+			if (obj.getProviderServiceMapID() != null
+					&& beneficiaryFlowStatusRepo.countNikshayMappedUsersForPSM(obj.getProviderServiceMapID()) > 0) {
+				if (obj.getDistrictID() != null) {
+					String correctDistrictName = beneficiaryFlowStatusRepo.getNikshayDistrictName(obj.getDistrictID());
+					if (correctDistrictName != null) {
+						obj.setDistrictName(correctDistrictName);
+					}
+				}
+				if (obj.getVillageID() != null) {
+					String correctVillageName = beneficiaryFlowStatusRepo.getNikshayVillageName(obj.getVillageID());
+					if (correctVillageName != null) {
+						obj.setVillageName(correctVillageName);
+					}
+				}
+			}
+		} catch (Exception e) {
+			// Never let a Nikshay-name lookup failure block registration - worst case the
+			// display text stays whatever the client sent, same as before this fix existed.
+			logger.warn("Nikshay district/village name resolution failed, keeping client-sent text: " + e.getMessage());
+		}
 
 		if (obj.getI_bendemographics().getServicePointID() != null)
 			obj.setServicePointID(obj.getI_bendemographics().getServicePointID());


### PR DESCRIPTION
…client text

Stop TB's district/village IDs are Nikshay-scoped (m_nikshay_district, m_nikshay_village), not AMRIT's general m_district/m_village numbering. The two ID spaces overlap - e.g. ID 1 means 'Nicobars' in m_district but 'Alluri Sitharama Raju' in m_nikshay_district - and i_ben_flow_outreach previously just stored whatever district/village name text the client sent verbatim, with no server-side validation. Observed live: two beneficiaries in the same actual village had different district/village text stored for the same numeric IDs.

Gated on countNikshayMappedUsersForPSM() so only PSMs actually mapped to a Nikshay TU go through this resolution - every other program (ANC/NCD/ cancer-screening/teleconsultation/etc.) sharing this same BenFlowStatus code path is unaffected and keeps using client-sent text exactly as before, since their IDs are already correctly AMRIT-scoped.

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
