### PR TITLE
fix(stoptb): read vanID from stoptb.van.id property instead of Redis

### DIFF
--- a/src/main/environment/common_ci.properties
+++ b/src/main/environment/common_ci.properties
@@ -70,6 +70,8 @@ spring.redis.host=@env.REDIS_HOST@
 
 # Stop TB: when true, beneficiary registration fails with an error if camp (vanID) is not configured
 stoptb.enforce.vanid=@env.STOPTB_ENFORCE_VANID@
+# Stop TB: this deployment's van/camp ID, replacing the old Redis camp:vanID lookup
+stoptb.van.id=@env.STOPTB_VAN_ID@
 jwt.secret=@env.JWT_SECRET_KEY@
 
 

--- a/src/main/environment/common_docker.properties
+++ b/src/main/environment/common_docker.properties
@@ -70,6 +70,8 @@ spring.redis.host=${REDIS_HOST}
 
 # Stop TB: when true, beneficiary registration fails with an error if camp (vanID) is not configured
 stoptb.enforce.vanid=${STOPTB_ENFORCE_VANID}
+# Stop TB: this deployment's van/camp ID, replacing the old Redis camp:vanID lookup
+stoptb.van.id=${STOPTB_VAN_ID}
 jwt.secret=${JWT_SECRET_KEY}
 
 #ELK logging file name

--- a/src/main/environment/common_example.properties
+++ b/src/main/environment/common_example.properties
@@ -72,6 +72,8 @@ spring.redis.host=localhost
 # Stop TB: when true, beneficiary registration fails with an error if camp (vanID)
 # is not configured instead of silently registering without it
 stoptb.enforce.vanid=false
+# Stop TB: this deployment's van/camp ID, replacing the old Redis camp:vanID lookup
+stoptb.van.id=0
 
 jwt.secret=my-32-character-ultra-secure-and-ultra-long-secret
 logging.path=logs/

--- a/src/main/java/com/iemr/tm/service/registrar/RegistrarServiceImpl.java
+++ b/src/main/java/com/iemr/tm/service/registrar/RegistrarServiceImpl.java
@@ -40,8 +40,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -114,8 +112,15 @@ public class RegistrarServiceImpl implements RegistrarService {
 	@Autowired
 	private CookieUtil cookieUtil;
 
-	@Autowired
-	private LettuceConnectionFactory redisConnectionFactory;
+	// This deployment's van/camp ID. Previously looked up from Redis ("camp:vanID"),
+	// written at MMU login and deleted (globally, unscoped) on ANY user's logout — a Redis
+	// outage or an unrelated user's logout would silently break registration on this camp.
+	// Each camp/van already runs its own dedicated backend instance, so which van this is
+	// never actually changes at runtime; reading it from properties removes the Redis
+	// dependency entirely. No inline default — every properties file must set this
+	// explicitly. Scope: vanID only, parkingPlaceID is not part of this change.
+	@Value("${stoptb.van.id}")
+	private int vanID;
 
 	// When true, beneficiary registration fails loudly if camp is not configured
 	// instead of silently registering with vanID unset. No inline default — every
@@ -671,26 +676,16 @@ public class RegistrarServiceImpl implements RegistrarService {
 		Long beneficiaryID = null;
 		Map<String, Object> responseMap = new HashMap<>();
 
-		// Inject correct vanID from Redis (mobile sends vanID=0 as placeholder)
-		byte[] vanIDBytes = null;
-		byte[] ppIDBytes = null;
-		try {
-			RedisConnection conn = redisConnectionFactory.getConnection();
-			vanIDBytes = conn.get("camp:vanID".getBytes());
-			ppIDBytes = conn.get("camp:parkingPlaceID".getBytes());
-			conn.close();
-		} catch (Exception e) {
-			logger.warn("Camp vanID lookup failed: " + e.getMessage());
-		}
-		if (vanIDBytes != null) {
+		// Inject configured vanID (mobile sends vanID=0 as placeholder). Previously looked
+		// up from Redis at request time; now a fixed property of this deployment (see
+		// vanID field javadoc above).
+		if (vanID > 0) {
 			JSONObject reqJson = new JSONObject(comingRequest);
-			reqJson.put("vanID", Integer.parseInt(new String(vanIDBytes)));
-			if (ppIDBytes != null)
-				reqJson.put("parkingPlaceID", Integer.parseInt(new String(ppIDBytes)));
+			reqJson.put("vanID", vanID);
 			comingRequest = reqJson.toString();
 		} else if (enforceVanID) {
 			throw new Exception(
-					"Camp not configured: vanID missing. Please select van/service point in MMU before registering beneficiary.");
+					"Camp not configured: stoptb.van.id is 0. Set stoptb.van.id in this deployment's properties file.");
 		}
 
 		RestTemplate restTemplate = new RestTemplate();


### PR DESCRIPTION
Redis (camp:vanID) was written once at MMU login and deleted globally, unscoped, on ANY user's logout — a Redis outage or an unrelated user's logout would silently break registration on this camp. Each camp/van already runs its own dedicated backend instance, so which van this is never actually changes at runtime.

registerBeneficiary() now injects vanID from the new stoptb.van.id property (no inline default, every properties file must set it explicitly, same convention as stoptb.enforce.vanid) instead of an inline Redis lookup. Removed the now-unused RedisConnection/ LettuceConnectionFactory dependency from this class.

Scope: vanID only, parkingPlaceID is not part of this change.

## 📋 Description

JIRA ID: 

Please provide a summary of the change and the motivation behind it. Include relevant context and details.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.
